### PR TITLE
Improve detection of date inputs

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -473,8 +473,7 @@ export default class bulmaCalendar extends EventEmitter {
     this._snapshots = [];
 
     // Cahnge element type to prevent browser default type="date" behavior
-    const type = this.element.getAttribute('type') || ''
-    if (type.toLowerCase() === 'date') {
+    if (this.element.tagName.toLowerCase() === 'input' && this.element.getAttribute('type').toLowerCase() === 'date') {
       this.element.setAttribute('type', 'text');
     }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -473,7 +473,8 @@ export default class bulmaCalendar extends EventEmitter {
     this._snapshots = [];
 
     // Cahnge element type to prevent browser default type="date" behavior
-    if (this.element.getAttribute('type').toLowerCase() === 'date') {
+    const type = this.element.getAttribute('type') || ''
+    if (type.toLowerCase() === 'date') {
       this.element.setAttribute('type', 'text');
     }
 


### PR DESCRIPTION
Previous behavior caused errors on some trigger elements, like `<a>`. This change fixes that.