### PR TITLE
Fix range-start and range-end overflow.

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -216,9 +216,11 @@ $calendar-date-padding: .1rem 0 !default
               &.calendar-range-end
                 border-radius: 25091983px
               &.calendar-range-start::before
-                left: 53%
+                left: 50%
+                width: 50%
               &.calendar-range-end::before
                 right: 50%
+                width: 50%
               .date-item
                 background-color: $primary
                 color: findColorInvert($primary)
@@ -341,7 +343,7 @@ $calendar-date-padding: .1rem 0 !default
   .calendar
     +calendar
 
-    
+
 .calendar
   +calendar
 

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -204,10 +204,12 @@ $calendar-date-padding: 0.4rem 0 !default;
 
             &.calendar-range-start::before {
                 left: 50%;
+                width: 50%;
             }
 
             &.calendar-range-end::before {
                 right: 50%;
+                width: 50%;
             }
 
             .date-item {


### PR DESCRIPTION
The rectangular range indicators were moved aside to allow the rounded
range-edge indicators to be visible. However, this caused the rectangular indicators
to overflow outside the calendar boundaries, as well as cover adjacent date-items.

Moving aside the indicators 50% means it will overflow 50% of its width. To solve
the issue we make the indicator's width  50% of its original width. Now there is
nothing left to overflow.

This fixes #104 .