### PR TITLE
Fix #106

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -271,6 +271,7 @@ $calendar-date-padding: .1rem 0 !default
   text-align: center
   max-width: 95%
   margin: auto
+  overflow: hidden
   &.is-active
     display: initial
   +calendar-header

--- a/src/sass/index.scss
+++ b/src/sass/index.scss
@@ -32,6 +32,7 @@ $calendar-date-padding: 0.4rem 0 !default;
         min-width: 20rem;
         text-align: center;
         max-width: 20rem;
+        overflow: hidden;
 
         &.is-active {
             display: initial;


### PR DESCRIPTION
Fix issue #106 by adding `overflow: hidden` to the `.calendar` class.

A question: Why there are a .sass and a .scss file?