### PR TITLE
Only handle document clicks when calendar is open

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -191,6 +191,10 @@ export default class bulmaCalendar extends EventEmitter {
   }
 
   _onDocumentClick(e) {
+    if (!this._open) {
+      return;
+    }
+    
     if (!this._supportsPassive) {
       e.preventDefault();
     }
@@ -198,7 +202,7 @@ export default class bulmaCalendar extends EventEmitter {
 
     // Check is e.target not within datepicker element
     const target = e.target || e.srcElement;
-    if (!this._ui.wrapper.contains(target) && this.options.displayMode !== 'inline' && this._open) {
+    if (!this._ui.wrapper.contains(target) && this.options.displayMode !== 'inline') {
       this._onClose(e);
     }
   }


### PR DESCRIPTION
This change ensures that click events reaching the document handler are only processed when the calendar is open.

Before this change, bulma-calendar processed all click events reaching the document, which breaks non-calendar functionality.