### PR TITLE
Make `showHeader` option work again

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -514,6 +514,9 @@ export default class bulmaCalendar extends EventEmitter {
       }
     };
 
+    if (!this.options.showHeader) {
+      this._ui.header.container.classList.add('is-hidden');
+    }
     if (!this.options.showFooter) {
       this._ui.footer.container.classList.add('is-hidden');
     }


### PR DESCRIPTION
It's currently impossible to disable the header. This chunk was deleted in 6fba33, probably by accident