### PR TITLE
Change input max-width to 80%

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -522,7 +522,7 @@ $calendar-date-padding: .1rem 0 !default
       text-indent: 1rem
       flex: 1
       height: 100%
-      max-width: 50%
+      max-width: 80%
       &:first-child
         text-indent: 2.5rem
       &.is-datetimepicker-range


### PR DESCRIPTION
I had an issue when displaying date and time in the input where the time was clipped because the max-width was set to 50% (which seems to very narrow for no apparent reason). I propose increasing it to 80%.