### PR TITLE
fix: Invalid SASS file containing semicolons

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -90,14 +90,14 @@ $calendar-date-padding: .1rem 0 !default
 					font-size: 1.5rem
 					font-weight: 100
 					color: #4a4a4a
-					border: 0;
+					border: 0
 					text-align: right
 				.datetimepicker-selection-input-minutes
 					width: 31px
 					font-size: 1.5rem
 					font-weight: 100
 					color: #4a4a4a
-					border: 0;
+					border: 0
 					margin-left: -5px
 		.datetimepicker-selection-start,
 		.datetimepicker-selection-end


### PR DESCRIPTION
The current bulma-calendar has an invalid SASS file which immediately broke my builds.