### PR TITLE
Fixes deprecation warnings in 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "bulma-calendar",
       "version": "6.1.13",
       "license": "MIT",
       "dependencies": {
@@ -44,7 +45,7 @@
         "webpack-stream": "^4.0.3"
       },
       "peerDependencies": {
-        "bulma": "*"
+        "bulma": "^0.9.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7484,6 +7485,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -16793,6 +16795,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "date-fns": "^2.21.3"
   },
   "peerDependencies": {
-    "bulma": "*"
+    "bulma": "^0.9.3"
   },
   "devDependencies": {
     "ansi-colors": "^2.0.1",

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -1,5 +1,5 @@
-@import "~bulma/sass/utilities/controls.sass"
-@import "~bulma/sass/elements/form.sass"
+@import "~bulma/sass/utilities/functions.sass"
+@import "~bulma/sass/form/shared.sass"
 
 $calendar-border: .1rem solid $white-ter !default
 $calendar-border-radius: $radius-small !default


### PR DESCRIPTION
fixes this warning:

```
WARNING: The form.sass file is DEPRECATED. It has moved into its own /form folder. Please import sass/form/_all instead.
    node_modules/bulma/sass/elements/form.sass 1:1       @import
    node_modules/bulma-calendar/src/sass/index.sass 2:9  @import
    app/frontend/stylesheets/datepicker.sass 4:9         root stylesheet
```

This is probably breaking change for bulma-calendar, but it's better to fix bulma version since they're adding breaking changes as well
Please let me know what you think